### PR TITLE
target_ws (humble): use one-function-per-file `rosidl`

### DIFF
--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -56,8 +56,8 @@ repositories:
     version: 2.8.2
   ros2/rosidl:
     type: git
-    url: https://github.com/ros2/rosidl.git
-    version: 3.1.5
+    url: https://github.com/yaskawa-global/rosidl.git
+    version: one_func_per_file
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git


### PR DESCRIPTION
As per title.

Allow older GCC versions (which don't support `--gc-sections` properly/fully) to benefit from linking in smaller object files.

This is the same change as merged earlier (but in `_buildscripts`).
