### PR TITLE
`target_ws`: bump `motoros2_interfaces` to `0.1.2`

### DIFF
--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -139,4 +139,4 @@ repositories:
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git
-    version: 0.1.1
+    version: 0.1.2


### PR DESCRIPTION
As per title.

Release pending (Yaskawa-Global/motoros2_interfaces#20), but we can already bump here as the tag does exist.

---

Edit: we'll backport this to `galactic` and `galactic-foxy_msgs`.
