### PR TITLE
target_ws: bump motoros2_interfaces to 0.1.2 (backport #5)

### DIFF
--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -174,5 +174,4 @@ repositories:
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git
-    # branch: main
-    version: 134e2b4110f21f5e72aadf9f5af30644a46573b0
+    version: 0.1.2


### PR DESCRIPTION
As per title.
