### PR TITLE
target_ws: bump motoros2_interfaces to 0.1.3 (backport #8)

### DIFF
--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -170,4 +170,4 @@ repositories:
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git
-    version: 0.1.2
+    version: 0.1.3


### PR DESCRIPTION
Backport #8 