### PR TITLE
Upgrade to jazzy

### DIFF
--- a/host_ws_pkgs.ignore
+++ b/host_ws_pkgs.ignore
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 ament/ament_cmake/ament_cmake_auto
-ament/ament_cmake/ament_cmake_gen_version_h
 ament/ament_cmake/ament_cmake_google_benchmark
 ament/ament_lint
 ament/googletest

--- a/host_ws_pkgs.repos
+++ b/host_ws_pkgs.repos
@@ -15,32 +15,32 @@ repositories:
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.11.2
+    version: 0.12.0
   ament/ament_cmake:
     type: git
     # this is the only fork needed.
     # ament_cmake_core needs two patches (for now),
-    # otherwise this is vanilla upstream 2.0.4
+    # otherwise this is one commit past upstream 2.5.2
     url: https://github.com/yaskawa-global/ament_cmake.git
-    # branch: 'iron-motoplus1-candidate-20240327'
-    version: a5960498ca28d56f9a535a4fb15830624daed5c3
+    # branch: 'jazzy'
+    version: 6569c90429302b56cbf888e5b732821cc42d99fb
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 1.5.2
+    version: 1.8.1
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.14.3
+    version: 0.17.1
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.15.3
+    version: 0.16.3
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: 1.10.9005
+    version: 1.14.9000
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: 2.1.2
+    version: 3.0.0

--- a/host_ws_pkgs.repos
+++ b/host_ws_pkgs.repos
@@ -15,32 +15,32 @@ repositories:
   ros2/ament_cmake_ros:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
-    version: 0.10.0
+    version: 0.11.2
   ament/ament_cmake:
     type: git
     # this is the only fork needed.
     # ament_cmake_core needs two patches (for now),
-    # otherwise this is vanilla upstream 1.3.5
+    # otherwise this is vanilla upstream 2.0.4
     url: https://github.com/yaskawa-global/ament_cmake.git
-    # branch: 'humble-motoplus1-candidate-20230624'
-    version: adb8bf83849c541a92ba7ea24d038757eafd2a47
+    # branch: 'iron-motoplus1-candidate-20240327'
+    version: a5960498ca28d56f9a535a4fb15830624daed5c3
   ament/ament_index:
     type: git
     url: https://github.com/ament/ament_index.git
-    version: 1.4.0
+    version: 1.5.2
   ament/ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.12.6
+    version: 0.14.3
   ament/ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.14.0
+    version: 0.15.3
   ament/googletest:
     type: git
     url: https://github.com/ament/googletest.git
-    version: 1.10.9004
+    version: 1.10.9005
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
-    version: 2.0.2
+    version: 2.1.2

--- a/target_ws_pkgs.ignore
+++ b/target_ws_pkgs.ignore
@@ -32,7 +32,6 @@ ros2/rcl_interfaces/test_msgs
 ros2/rcl_logging/rcl_logging_spdlog
 ros2/rclc/rclc_examples
 ros2/rclc/rclc_lifecycle
-ros2/rcpputils
 ros2/rmw_implementation/test_rmw_implementation
 ros2/rosidl/rosidl_generator_tests
 ros2/rosidl/rosidl_typesupport_introspection_cpp
@@ -48,3 +47,4 @@ uros/tracetools/tracetools_launch
 uros/tracetools/tracetools_read
 uros/tracetools/tracetools_test
 uros/tracetools/tracetools_trace
+uros/tracetools/lttngpy

--- a/target_ws_pkgs.ignore
+++ b/target_ws_pkgs.ignore
@@ -34,11 +34,14 @@ ros2/rclc/rclc_examples
 ros2/rclc/rclc_lifecycle
 ros2/rcpputils
 ros2/rmw_implementation/test_rmw_implementation
+ros2/rosidl/rosidl_generator_tests
 ros2/rosidl/rosidl_typesupport_introspection_cpp
 ros2/rosidl/rosidl_typesupport_introspection_tests
 uros/rcl/rcl_lifecycle
+uros/rosidl_typesupport/rosidl_typesupport_tests
 uros/rosidl_typesupport_microxrcedds/test
 uros/tracetools/ros2trace
+uros/tracetools/test_ros2trace
 uros/tracetools/test_tracetools
 uros/tracetools/test_tracetools_launch
 uros/tracetools/tracetools_launch

--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -39,7 +39,7 @@ repositories:
     url: https://github.com/ros2/rclc.git
     # NOTE: see the release notes: https://github.com/ros2/rclc/releases/tag/5.0.1
     # especially the PRs touching rosout logging init
-    # NOTE 2: this is two commit past '5.0.1', fixing the clash with 'NONE'.
+    # NOTE 2: this is two commits past '5.0.1', fixing the clash with 'NONE'.
     # See: https://github.com/ros2/rclc/issues/378
     version: 24ab126bb489984c2b66a72d2ce56e221dd707d1
   ros2/rcpputils:
@@ -97,8 +97,7 @@ repositories:
   uros/micro_ros_utilities:
     type: git
     url: https://github.com/micro-ROS/micro_ros_utilities.git
-    # three commits past 4.0.1
-    version: 74f7a6b08690079ecbb0262db563aa96f667277d
+    version: 4.0.2
   uros/rmw-microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -122,7 +121,7 @@ repositories:
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 5.0.0
+    version: 5.0.1
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
@@ -147,8 +146,8 @@ repositories:
   extra/ros-controls/control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    # technically on 'rolling', but this seems the version released into Iron ..
-    version: 5.0.0
+    # technically on 'rolling', but this is the version released into Iron ..
+    version: 5.2.0
   extra/ros2/geometry2_tf2_msgs:
     type: git
     url: https://github.com/ros2/geometry2.git

--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-# Revisions checked out mostly target ROS 2 Iron (or the micro-ROS equivalents).
+# Revisions checked out mostly target ROS 2 Jazzy (or the micro-ROS equivalents).
 #
 # NOTE: this list has not been pruned. It's possible some of these repositories
 # are not actually needed for the MotoPlus platform.
@@ -28,114 +28,115 @@ repositories:
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.5.0
+    version: 1.6.3
 
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: 2.5.1
+    version: 3.1.0
   ros2/rclc:
     type: git
     url: https://github.com/ros2/rclc.git
-    # NOTE: see the release notes: https://github.com/ros2/rclc/releases/tag/5.0.1
-    # especially the PRs touching rosout logging init
-    # NOTE 2: this is two commits past '5.0.1', fixing the clash with 'NONE'.
-    # See: https://github.com/ros2/rclc/issues/378
-    version: 24ab126bb489984c2b66a72d2ce56e221dd707d1
-  ros2/rcpputils:
-    # NOTE: we don't actually use this package in MotoROS2
-    # TODO: check whether we can drop this completely
-    type: git
-    url: https://github.com/ros2/rcpputils.git
-    version: 2.6.3
+    version: 995cda8c68456c7477ed103d9419a161fd068960
 
   ros2/rmw:
     type: git
     url: https://github.com/yaskawa-global/rmw.git
-    # branch: 'iron-motoplus1'
-    version: 1ae820c60cb101cce294cd4b5320344fd1d72862
+    version: cb84993f73d74f308230fe6b2223f8711252dece
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.12.0
+    version: 2.15.3
   # needed because of https://github.com/ros2/rcl_interfaces/issues/144
   ros2/rosidl:
     type: git
     url: https://github.com/ros2/rosidl.git
-    version: 4.0.1
+    version: 4.6.4
   ros2/rosidl_core:
     type: git
     url: https://github.com/ros2/rosidl_core.git
-    version: 0.1.1
+    version: 0.2.0
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: 0.10.1
+    version: 0.11.1
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 1.5.0
+    version: 1.6.0
   ros2/rosidl_dynamic_typesupport:
     type: git
     url: https://github.com/ros2/rosidl_dynamic_typesupport.git
-    version: 0.0.5
+    version: 0.1.2
 
   uros/rcl:
     type: git
     # this is a regular fork, but renamed due to potential clashes with ros2/rcl
     url: https://github.com/yaskawa-global/micro_ros_rcl.git
-    # NOTE: the fork adds additional patches, on top of 'upstream/iron'.
-    #       Branch name: 'iron-wip-candidate-20240327'
-    # NOTE2: micro-ROS devs have made substantial changes to argument parsing infrastructure
-    #        and renamed compile time flags/CMake flags etc. Not sure this all still works
-    version: 0ef890438f8a3919fe07fe6b57d590fc8a8f2466
+    # NOTE: the fork adds 6 additional patches, on top of 'upstream/jazzy'.
+    # Branch name: 'jazzy'
+    version: 032fee21bcbd75ad0a8b43fe5f1a6c983d5f0d34
   uros/rcutils:
     type: git
     url: https://github.com/yaskawa-global/rcutils.git
-    # Branch name: 'iron-motoplus1-candidate-20240327'
-    version: d1675fb79c76ba7d9ed426e23d2fcc7d7e211d58
+    # 'upstream/jazzy' (couple commits past 6.7.2), with 6 patches
+    #  Branch name: 'jazzy'
+    version: 0512f00dc515c1866eec5dc732e10f41228b707f
   uros/micro_ros_utilities:
     type: git
     url: https://github.com/micro-ROS/micro_ros_utilities.git
-    version: 4.0.2
+    version: 5.0.1
   uros/rmw-microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
-    version: 4.0.1
+    version: 5.0.1
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/yaskawa-global/rosidl_typesupport.git
-    # Branch name: 'iron-wip-candidate-20240327'
-    version: 7b4c3d2c3b559f5f02a5783ebd0c9fd1e2c36e28
+    # 'upstream/jazzy' with a single patch of our own
+    #  Branch name: 'jazzy'
+    version: 79885fc1a3e73e0e4205475e7e3804bba73e1e1d
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git
-    version: 4.0.1
+    version: 5.0.1
+
+
 
   uros/tracetools:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 6.3.1
+    version: 8d898b5ff0d79ef34eeae73a6ef3a20b30fe1ac8
+    # NOTE: this is not the same as the jazzy release. 
+    # This is a commit on rolling which is a few commits
+    # past where jazzy and rolling diverged. 
+    # This commit contains a necessary change
+    # The __attribute__((deprecated(msg))) form is 
+    # only supported in GCC version 4.5+, which is newer than 
+    # what we are using. The MotoPlus compiler does not like this line:
+    # https://github.com/ros2/ros2_tracing/blob/42e26cca398246db56881e17394abf9f8d3b7755/tracetools/include/tracetools/tracetools.h#L130
+    # We could make a new fork and cherry pick this commit instead
+    # but decided against it to avoid having to maintain a fork. 
 
   # messages/services/actions
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 5.0.1
+    version: 5.3.5
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 1.6.0
+    version: 2.0.2
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.3.2
+    version: 2.5.0
 
   # only used to determine the ROS 2 codename during packaging
   ros2/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: 4.1.1
+    version: 4.2.1
 
   # extra dependencies needed for MotoROS2
   extra/industrial_msgs:
@@ -146,12 +147,11 @@ repositories:
   extra/ros-controls/control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    # technically on 'rolling', but this is the version released into Iron ..
     version: 5.2.0
   extra/ros2/geometry2_tf2_msgs:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.31.5
+    version: 0.36.4
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git

--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-# Revisions checked out mostly target ROS 2 Humble (or the micro-ROS equivalents).
+# Revisions checked out mostly target ROS 2 Iron (or the micro-ROS equivalents).
 #
 # NOTE: this list has not been pruned. It's possible some of these repositories
 # are not actually needed for the MotoPlus platform.
@@ -19,108 +19,124 @@ repositories:
   eProsima/Micro-XRCE-DDS-Client:
     type: git
     url: https://github.com/yaskawa-global/microxrcedds_client_motoplus.git
-    # this is 'develop' from upstream, but with our own patches
-    # branch name: 'motoplus_dev/upstream/develop_with_patches-iron_update'
+    # this is 2.4.3 from upstream, but with our own patches
+    # branch name: 'motoplus_dev/upstream/v2.4.3_with_patches_iron'
     # NOTE: name says 'iron', but the same versions appear to be used for all
     # supported ROS 2 distributions
-    version: 2ae3b964aef3bf1609d39dad1e188dbcadfeeeab
+    version: 3178c635e09b73b371808c3be2d33e5109b74e9f
 
   ros2/libyaml_vendor:
     type: git
     url: https://github.com/ros2/libyaml_vendor.git
-    version: 1.2.2
+    version: 1.5.0
 
   ros2/rcl_logging:
     type: git
     url: https://github.com/ros2/rcl_logging.git
-    version: 2.3.1
+    version: 2.5.1
   ros2/rclc:
     type: git
     url: https://github.com/ros2/rclc.git
-    version: 4.0.2
+    # NOTE: see the release notes: https://github.com/ros2/rclc/releases/tag/5.0.1
+    # especially the PRs touching rosout logging init
+    # NOTE 2: this is two commit past '5.0.1', fixing the clash with 'NONE'.
+    # See: https://github.com/ros2/rclc/issues/378
+    version: 24ab126bb489984c2b66a72d2ce56e221dd707d1
   ros2/rcpputils:
     # NOTE: we don't actually use this package in MotoROS2
     # TODO: check whether we can drop this completely
     type: git
     url: https://github.com/ros2/rcpputils.git
-    version: 2.4.1
+    version: 2.6.3
 
   ros2/rmw:
     type: git
     url: https://github.com/yaskawa-global/rmw.git
-    # update. Branch: 'humble-motoplus1'
-    version: c705eb5260c47163399ee60f50da5253b1af992b
+    # branch: 'iron-motoplus1'
+    version: 1ae820c60cb101cce294cd4b5320344fd1d72862
   ros2/rmw_implementation:
     type: git
     url: https://github.com/ros2/rmw_implementation.git
-    version: 2.8.2
+    version: 2.12.0
+  # needed because of https://github.com/ros2/rcl_interfaces/issues/144
   ros2/rosidl:
     type: git
-    url: https://github.com/yaskawa-global/rosidl.git
-    version: one_func_per_file
+    url: https://github.com/ros2/rosidl.git
+    version: 4.0.1
+  ros2/rosidl_core:
+    type: git
+    url: https://github.com/ros2/rosidl_core.git
+    version: 0.1.1
   ros2/rosidl_dds:
     type: git
     url: https://github.com/ros2/rosidl_dds.git
-    version: 0.8.1
+    version: 0.10.1
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
-    version: 1.2.0
+    version: 1.5.0
+  ros2/rosidl_dynamic_typesupport:
+    type: git
+    url: https://github.com/ros2/rosidl_dynamic_typesupport.git
+    version: 0.0.5
 
   uros/rcl:
     type: git
     # this is a regular fork, but renamed due to potential clashes with ros2/rcl
     url: https://github.com/yaskawa-global/micro_ros_rcl.git
-    # NOTE: the fork adds additional patches, on top of 'upstream/humble'.
-    #       Branch name: 'humble-motoplus1-candidate-20230624'
-    version: 1423adabdf10cd3165244e77479763d44bf5945a
+    # NOTE: the fork adds additional patches, on top of 'upstream/iron'.
+    #       Branch name: 'iron-wip-candidate-20240327'
+    # NOTE2: micro-ROS devs have made substantial changes to argument parsing infrastructure
+    #        and renamed compile time flags/CMake flags etc. Not sure this all still works
+    version: 0ef890438f8a3919fe07fe6b57d590fc8a8f2466
   uros/rcutils:
     type: git
     url: https://github.com/yaskawa-global/rcutils.git
-    # 'upstream/humble' (couple commits past 5.1.3), with 5 patches
-    version: c8ec6220ae77d3363de4c377485fd9c653be2936
+    # Branch name: 'iron-motoplus1-candidate-20240327'
+    version: d1675fb79c76ba7d9ed426e23d2fcc7d7e211d58
   uros/micro_ros_utilities:
     type: git
     url: https://github.com/micro-ROS/micro_ros_utilities.git
-    version: 3.0.1
+    # three commits past 4.0.1
+    version: 74f7a6b08690079ecbb0262db563aa96f667277d
   uros/rmw-microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
-    version: 3.0.2
+    version: 4.0.1
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/yaskawa-global/rosidl_typesupport.git
-    # 'upstream/humble' with a single patch of our own
-    version: fea3ab8a497b87b04d489d7cfb733a8455b90fad
+    # Branch name: 'iron-wip-candidate-20240327'
+    version: 7b4c3d2c3b559f5f02a5783ebd0c9fd1e2c36e28
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git
-    version: 3.0.1
+    version: 4.0.1
 
   uros/tracetools:
     type: git
     url: https://github.com/ros2/ros2_tracing.git
-    version: 4.1.1
+    version: 6.3.1
 
   # messages/services/actions
   ros2/common_interfaces:
     type: git
     url: https://github.com/ros2/common_interfaces.git
-    version: 4.2.3
+    version: 5.0.0
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 1.2.1
+    version: 1.6.0
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
-    version: 2.2.1
+    version: 2.3.2
 
   # only used to determine the ROS 2 codename during packaging
   ros2/ros_environment:
     type: git
     url: https://github.com/ros/ros_environment.git
-    version: 3.2.2
+    version: 4.1.1
 
   # extra dependencies needed for MotoROS2
   extra/industrial_msgs:
@@ -131,11 +147,12 @@ repositories:
   extra/ros-controls/control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: 4.4.0
+    # technically on 'rolling', but this seems the version released into Iron ..
+    version: 5.0.0
   extra/ros2/geometry2_tf2_msgs:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: 0.25.3
+    version: 0.31.5
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git


### PR DESCRIPTION
Do not merge. This branch should stay separate. The PR is only here to review/discuss. 

Required for https://github.com/Yaskawa-Global/motoros2/pull/337 

I can squash the commits if that would be cleaner. 

Notable changes (not just update upstream/cherry pick) include https://github.com/micro-ROS/rcl/compare/jazzy...Yaskawa-Global:micro_ros_rcl:jazzy and https://github.com/ament/ament_cmake/compare/jazzy...Yaskawa-Global:ament_cmake:jazzy.

Please review and comment on those comparisons here (making PRs in those repos doesn't make sense) 

ros2_tracetools is also notable because it is the only non-fork that doesn't match up with the [jazzy release targets](https://github.com/ros2/ros2/releases/tag/release-jazzy-20240919). I had to target a more up-to-date version to avoid breaking the build. The targeted commit is the one that fixes the problem that broke the build. 

Additionally, I chose a specific commit for motoros2_interfaces because the most recent release 0.1.3 is not compatible with the most up-to-date commits of MotoROS2.

I did not update jazzy to match [`rosidl`'s `one_func_per_file`](https://github.com/Yaskawa-Global/rosidl/tree/one_func_per_file) branch. I am just pulling directly from upstream. If we need the `one_func_per_file` style, I can do that. 

I also got rid of the `rcpputils` package. I know that this should probably be a separate PR, and I can do that if needed. But it was just easier because it isn't required and removing it sped up the build (which I had to do many times). 