### PR TITLE
`target_ws`: bump motoros2_interfaces to `0.2.0`

### DIFF
--- a/target_ws_pkgs.repos
+++ b/target_ws_pkgs.repos
@@ -155,4 +155,4 @@ repositories:
   extra/motoros2_interfaces:
     type: git
     url: https://github.com/yaskawa-global/motoros2_interfaces.git
-    version: 0.1.4
+    version: 0.2.0


### PR DESCRIPTION
Will backport this change to other branches as well.